### PR TITLE
Added an alternate apt-get command for pyzbar

### DIFF
--- a/QR_Attendance/requirements.txt
+++ b/QR_Attendance/requirements.txt
@@ -3,6 +3,8 @@
 2. tkinter - pip install tk-tools 
            - pip install tk
 
-3. pyzbar  - apt-get install zbar-tools
+3. pyzbar  - pip install pyzbar
+             OR
+           - apt-get install zbar-tools
 
 4. cv2     - pip install opencv-python

--- a/QR_Attendance/requirements.txt
+++ b/QR_Attendance/requirements.txt
@@ -3,6 +3,6 @@
 2. tkinter - pip install tk-tools 
            - pip install tk
 
-3. pyzbar  - pip install pyzbar
+3. pyzbar  - apt-get install zbar-tools
 
 4. cv2     - pip install opencv-python


### PR DESCRIPTION
Loved your project!

I tried to run the project on three different Ubuntu systems.
But despite trying to download 'pyzbar' from the requirements using the pip command, and it being downloaded successfully... 
It always gave out the error: "[ImportError: Unable to find zbar shared library on Flask]"

In this PR I've added an alternate apt-get command so that the non tech-savvy users don't feel inconvenienced by the error.